### PR TITLE
feat: pickup all of the default stylable config

### DIFF
--- a/fixtures/demo/stylable.config.js
+++ b/fixtures/demo/stylable.config.js
@@ -5,6 +5,7 @@ const { createDefaultResolver } = require('@stylable/core');
 module.exports = {
     defaultConfig(fs) {
         return {
+            experimentalSelectorInference: true,
             resolveModule: createDefaultResolver(fs, {
                 alias: {
                     comps: join(__dirname, 'alias-components'),

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -28,18 +28,18 @@ connection.onInitialize(async (params) => {
     const rootFsPath = rootUri && URI.parse(rootUri).fsPath;
     const configPath = rootFsPath && join(rootFsPath, 'stylable.config.js');
 
-    const resolveModule = await loadConfigFile(configPath);
+    const config = await loadConfigFile(configPath);
 
     vscodeStylableLSP = new VscodeStylableLanguageService(
         connection,
         docs,
         wrappedFs,
         new Stylable({
+            ...config,
             projectRoot: rootFsPath || '',
             fileSystem: wrappedFs,
             requireModule: require,
             cssParser: safeParse,
-            resolveModule,
         })
     );
 
@@ -69,7 +69,7 @@ connection.onInitialized(() => {
 });
 
 async function loadConfigFile(configPath: string | null) {
-    let resolveModule;
+    let config: StylableConfig | undefined = undefined;
 
     try {
         if (configPath) {
@@ -77,8 +77,7 @@ async function loadConfigFile(configPath: string | null) {
                 defaultConfig: (fs: MinimalFS) => StylableConfig;
             };
 
-            resolveModule =
-                defaultConfig && typeof defaultConfig === 'function' ? defaultConfig(fs).resolveModule : undefined;
+            config = defaultConfig && typeof defaultConfig === 'function' ? defaultConfig(fs) : undefined;
         }
     } catch (e: unknown) {
         console.warn(
@@ -90,5 +89,5 @@ async function loadConfigFile(configPath: string | null) {
         );
     }
 
-    return resolveModule;
+    return config;
 }


### PR DESCRIPTION
This PR changes the extension server to pickup all of the fields from the `stylable.config` - not just the `resolveModule`.

In addition it adds the new `experimentalSelectorInference` to the internal demo.